### PR TITLE
Iss6 stage files with delay (#10)

### DIFF
--- a/cart/cart_interface.py
+++ b/cart/cart_interface.py
@@ -8,7 +8,7 @@ from tarfile import TarFile
 import doctest
 from urlparse import parse_qs
 import cart.cart_interface_responses as cart_interface_responses
-from cart.tasks import stage_files
+from cart.tasks import create_cart
 from cart.cart_utils import Cartutils
 
 
@@ -147,7 +147,7 @@ class CartGenerator(object):
                 start_response, uid)
             return self.return_response()
 
-        stage_files(file_ids, uid)
+        create_cart(file_ids, uid)
         self._response = resp.cart_proccessing_response(start_response)
         return self.return_response()
 

--- a/cart/test/test_cart_utils.py
+++ b/cart/test/test_cart_utils.py
@@ -156,6 +156,14 @@ class TestCartUtils(unittest.TestCase):
                             "message": "File was found",
                             "mtime": "1444938166"
                             }"""
+            resp_bad = """{
+                            "bytes_per_level": "(0L, 33L, 33L, 0L, 0L)",
+                            "ctime": "1444938177",
+                            "file": "/myemsl-dev/bundle/file.2",
+                            "filesize": "33",
+                            "message": "File was found",
+                            "mtime": "1444938133"
+                            }"""
             test_cart = Cart.create(cart_uid='1', status='staging')
             test_file = File.create(cart=test_cart, file_name='1.txt',
                                     bundle_path='/tmp/1/1.txt')
@@ -166,6 +174,11 @@ class TestCartUtils(unittest.TestCase):
 
             #now check for an error by sending a bad response
             ready = cart_utils.check_file_ready_pull('', test_file, test_cart)
+            self.assertEqual(ready, -1)
+            self.assertEqual(test_file.status, 'error')
+
+            #now check for an error with storage media
+            ready = cart_utils.check_file_ready_pull(resp_bad, test_file, test_cart)
             self.assertEqual(ready, -1)
             self.assertEqual(test_file.status, 'error')
 
@@ -188,7 +201,7 @@ class TestCartUtils(unittest.TestCase):
             cart_utils = Cartutils()
             ready = cart_utils.check_file_ready_pull(response, test_file,
                                                      test_cart)
-            self.assertEqual(ready, True)
+            self.assertEqual(ready['enough_space'], True)
             self.assertNotEqual(test_file.status, 'error')
 
     def test_delete_cart_bundle(self):


### PR DESCRIPTION
* Making the creation of a cart faster by not making it dependednt on number of files

* Fixing a race condition with updating cart status

* trying to alleviate race condition

* Debugging lines

* Moving where prepare bundle happens to relieve race condition

* Moving prepare bundle to be a check after ever pulled file

* Moving prepare bundle and tar files out of tasks and into the cart utils

* Fixing naming issue

* putting query back to peewee style

* fixing another cart query bug

* fixing bad cart reference

* Updating tasks by moving some code to the utils.  fixing some pylint issues

* Pylint cleanup

* Fixing failing unit test with new file_ready_pull return

* fixing bug with successful cart file saving. Also fixing error message when file path cant be created

* Updating unit tests to fix code coverage

* reducing some of the cyclomatic complexity

* fixing more cyclomatic complexity

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
